### PR TITLE
Add representation for science task in the primary CTA.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <section class="primary-cta">
   <h1>Welcome to NIU Mars Rover!</h1>
-  <p>Open to all majors, the Mars Rover Team is a student organization in NIU's College of Engineering and Engineering Technology. The team offers students the opportunity to learn about the design, fabrication, and integration of mechanical, electrical, and computer systems - key aspects of the rover's operation. All of these components come together to perform scientific tasks such as analyzing soil samples for life.  The team competes in the <a href="http://urc.marssociety.org/">University Rover Challenge</a>, held each year in May.</p>
+  <p>Open to all majors, the Northern Illinois University Mars Rover Team is a student organization in NIU's College of Engineering and Engineering Technology. The team offers students the opportunity to learn about the design, fabrication, and integration of mechanical, electrical, and computer systems - key aspects of the rover's operation. All of these components come together to perform scientific tasks such as analyzing soil samples for life.  The team competes in the <a href="http://urc.marssociety.org/">University Rover Challenge</a>, held each year in May.</p>
 </section>
 <section class="home-bloglist">
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <section class="primary-cta">
   <h1>Welcome to NIU Mars Rover!</h1>
-  <p>Open to all majors, the Northern Illinois University Mars Rover team is a student organization in NIU’s College of Engineering and Engineering Technology. This team offers NIU students education and experience relating to the design, fabrication, and integration of mechanical, electrical, and computer systems relevant to our rover’s operation. The main competition we target is the <a href="http://urc.marssociety.org/">University Rover Challenge</a>, held each year in May.</p>
+  <p>Open to all majors, the Mars Rover Team is a student organization in NIU's College of Engineering and Engineering Technology. The team offers students the opportunity to learn about the design, fabrication, and integration of mechanical, electrical, and computer systems - key aspects of the rover's operation. All of these components come together to perform scientific tasks such as analyzing soil samples for life.  The team competes in the <a href="http://urc.marssociety.org/">University Rover Challenge</a>, held each year in May.</p>
 </section>
 <section class="home-bloglist">
 


### PR DESCRIPTION
I had assigned myself this task back in September, but forgot to get around to it.

This PR replaces the existing primary CTA with the paragraph HAL & I drafted for the September promotional flyers.  The old paragraph didn't have any "science task" representation in it, so this is an attempt to ensure that all of our subteams are represented.

Feel free to check it over!